### PR TITLE
Add comprehensive emeritus.md tracking TAB member history

### DIFF
--- a/emeritus.md
+++ b/emeritus.md
@@ -1,0 +1,103 @@
+# TAB Emeritus
+
+This document honors individuals who have served the CNCF End User community and Technical Advisory Board in leadership positions.
+
+## About This Record
+
+The CNCF End User community began in January 2019 as an informal, staff-coordinated group to connect cloud native technology end users. In June 2025, it was formalized as the **Technical Advisory Board (TAB)** with defined roles, governance, and elected/appointed positions.
+
+This record recognizes contributions across both eras:
+- **Pre-TAB Era (2019-2025)**: CNCF staff and coordinators who managed the community
+- **TAB Era (June 2025-present)**: Elected and appointed members serving in formal positions
+
+## Emeritus Members
+
+### TAB Era (2025-present)
+
+#### 2025
+
+**Amr Abdelhalem** ([@ahalem](https://github.com/ahalem))
+- Role: Gold Member Representative
+- Affiliation: Fidelity Investments
+- Served: June 12, 2025 - September 04, 2025
+
+## Pre-TAB Era Recognition (2019-2025)
+
+During the pre-TAB era, the End User Community operated as a staff-coordinated program rather than a formally governed body. Leadership roles were held by CNCF staff members who facilitated community activities, managed user groups, and coordinated events.
+
+### CNCF Staff & Community Coordinators
+
+**Cheryl Hung** ([@oicheryl](https://github.com/oicheryl))
+- Role: End User Community Coordinator
+- Affiliation: CNCF (2019-2020), later Arm
+- Period: January 2019 - June 2020 (primary coordination period)
+- Contributions: Established initial community structure, coordinated Tech Radar initiatives, managed community access and engagement
+
+**Taylor Waggoner** ([@taylorwaggoner](https://github.com/taylorwaggoner))
+- Role: End User Program Manager
+- Affiliation: CNCF / Linux Foundation
+- Period: 2019 - 2025
+- Contributions: Long-term program management, member services coordination, user group support
+
+**Chris Aniszczyk** ([@caniszczyk](https://github.com/caniszczyk))
+- Role: CNCF CTO / Senior Staff Coordinator
+- Affiliation: Linux Foundation / CNCF
+- Period: 2019 - 2020 (active coordination period)
+- Contributions: Established repository and community infrastructure, initiated SIG structure
+
+**Taylor Dolezal** ([@onlydole](https://github.com/onlydole))
+- Role: CNCF Staff / Contributor
+- Affiliation: CNCF
+- Period: 2022
+- Contributions: Major repository reorganization, added automation and link checking
+
+**Bob Killen** ([@mrbobbytables](https://github.com/mrbobbytables))
+- Role: CNCF Kubernetes & OSS Advocate
+- Affiliation: CNCF
+- Period: 2025
+- Contributions: Repository maintenance, meeting infrastructure, documentation improvements
+
+### Note on Pre-TAB Documentation
+
+Formal leadership positions (such as user group chairs or steering committee members) were likely documented in the private `cncf/enduser` repository rather than the public repository. The individuals listed above represent documented contributors to the public-facing community infrastructure.
+
+## Current Members
+
+For current TAB members, see [README.md](README.md#members).
+
+## Membership History
+
+### TAB Member Timeline
+
+**Platinum Member Seats**
+- Alolita Sharma (Apple) - June 12, 2025 to present
+- Chad Beaudin (Boeing) - June 12, 2025 to September 04, 2025 (moved to Invited seat)
+- Michael Amundson (CVS Health) - December 08, 2025 to present
+
+**Gold Member Seats**
+- Henrik Blixt (Intuit) - June 12, 2025 to present
+- Amr Abdelhalem (Fidelity Investments) - June 12, 2025 to September 04, 2025 (emeritus)
+
+**Silver Member Seats**
+- Ben Somogyi (Lockheed Martin) - June 12, 2025 to present
+- Kenta Tada (Toyota) - September 04, 2025 to present
+- Mike Bowen (Blackrock) - September 04, 2025 to present
+
+**At-large Seats**
+- Ahmed Bebars (The New York Times) - June 12, 2025 to present
+- Garry Cairns (JPMorgan) - June 12, 2025 to present
+- Joseph Sandoval (Adobe Inc, Vice-Chair) - June 12, 2025 to present
+
+**TOC Appointed Seats**
+- Ricardo Rocha (CERN, Chair) - June 12, 2025 to present
+- Katie Gamanji (Apple) - June 12, 2025 to present
+
+**Invited Seats**
+- Chad Beaudin (Boeing) - September 04, 2025 to present (previously Platinum member)
+
+## Additional Resources
+
+- [TAB Charter and Governance](README.md#purpose-and-duties)
+- [Current TAB Members](README.md#members)
+- [End User Community Information](https://www.cncf.io/enduser)
+- [TAB Meeting Notes](https://github.com/orgs/cncf/projects/60)

--- a/emeritus.md
+++ b/emeritus.md
@@ -2,17 +2,7 @@
 
 This document honors individuals who have served the CNCF End User community and Technical Advisory Board in leadership positions.
 
-## About This Record
-
-The CNCF End User community began in January 2019 as an informal, staff-coordinated group to connect cloud native technology end users. In June 2025, it was formalized as the **Technical Advisory Board (TAB)** with defined roles, governance, and elected/appointed positions.
-
-This record recognizes contributions across both eras:
-- **Pre-TAB Era (2019-2025)**: CNCF staff and coordinators who managed the community
-- **TAB Era (June 2025-present)**: Elected and appointed members serving in formal positions
-
 ## Emeritus Members
-
-### TAB Era (2025-present)
 
 #### 2025
 
@@ -20,80 +10,6 @@ This record recognizes contributions across both eras:
 - Role: Gold Member Representative
 - Affiliation: Fidelity Investments
 - Served: June 12, 2025 - September 04, 2025
-
-## Pre-TAB Era Recognition (2019-2025)
-
-During the pre-TAB era, the End User Community operated as a staff-coordinated program rather than a formally governed body. Leadership roles were held by CNCF staff members who facilitated community activities, managed user groups, and coordinated events.
-
-### CNCF Staff & Community Coordinators
-
-**Cheryl Hung** ([@oicheryl](https://github.com/oicheryl))
-- Role: End User Community Coordinator
-- Affiliation: CNCF (2019-2020), later Arm
-- Period: January 2019 - June 2020 (primary coordination period)
-- Contributions: Established initial community structure, coordinated Tech Radar initiatives, managed community access and engagement
-
-**Taylor Waggoner** ([@taylorwaggoner](https://github.com/taylorwaggoner))
-- Role: End User Program Manager
-- Affiliation: CNCF / Linux Foundation
-- Period: 2019 - 2025
-- Contributions: Long-term program management, member services coordination, user group support
-
-**Chris Aniszczyk** ([@caniszczyk](https://github.com/caniszczyk))
-- Role: CNCF CTO / Senior Staff Coordinator
-- Affiliation: Linux Foundation / CNCF
-- Period: 2019 - 2020 (active coordination period)
-- Contributions: Established repository and community infrastructure, initiated SIG structure
-
-**Taylor Dolezal** ([@onlydole](https://github.com/onlydole))
-- Role: CNCF Staff / Contributor
-- Affiliation: CNCF
-- Period: 2022
-- Contributions: Major repository reorganization, added automation and link checking
-
-**Bob Killen** ([@mrbobbytables](https://github.com/mrbobbytables))
-- Role: CNCF Kubernetes & OSS Advocate
-- Affiliation: CNCF
-- Period: 2025
-- Contributions: Repository maintenance, meeting infrastructure, documentation improvements
-
-### Note on Pre-TAB Documentation
-
-Formal leadership positions (such as user group chairs or steering committee members) were likely documented in the private `cncf/enduser` repository rather than the public repository. The individuals listed above represent documented contributors to the public-facing community infrastructure.
-
-## Current Members
-
-For current TAB members, see [README.md](README.md#members).
-
-## Membership History
-
-### TAB Member Timeline
-
-**Platinum Member Seats**
-- Alolita Sharma (Apple) - June 12, 2025 to present
-- Chad Beaudin (Boeing) - June 12, 2025 to September 04, 2025 (moved to Invited seat)
-- Michael Amundson (CVS Health) - December 08, 2025 to present
-
-**Gold Member Seats**
-- Henrik Blixt (Intuit) - June 12, 2025 to present
-- Amr Abdelhalem (Fidelity Investments) - June 12, 2025 to September 04, 2025 (emeritus)
-
-**Silver Member Seats**
-- Ben Somogyi (Lockheed Martin) - June 12, 2025 to present
-- Kenta Tada (Toyota) - September 04, 2025 to present
-- Mike Bowen (Blackrock) - September 04, 2025 to present
-
-**At-large Seats**
-- Ahmed Bebars (The New York Times) - June 12, 2025 to present
-- Garry Cairns (JPMorgan) - June 12, 2025 to present
-- Joseph Sandoval (Adobe Inc, Vice-Chair) - June 12, 2025 to present
-
-**TOC Appointed Seats**
-- Ricardo Rocha (CERN, Chair) - June 12, 2025 to present
-- Katie Gamanji (Apple) - June 12, 2025 to present
-
-**Invited Seats**
-- Chad Beaudin (Boeing) - September 04, 2025 to present (previously Platinum member)
 
 ## Additional Resources
 


### PR DESCRIPTION
I wanted to make sure Garry's contributions were noted and noticed that there's no emeritus.md in this repo. I had the agent go through the git history for other notable contributions and I figured why not track the history of each position anyway.

LMK if this is too long or if you prefer a more traditional emeritus.md. 

Assisted-by: Claude 3.5 Sonnet via GitHub Copilot