### PR TITLE
ci(linkchecker): declare contents: read

### DIFF
--- a/.github/workflows/linkchecker.yaml
+++ b/.github/workflows/linkchecker.yaml
@@ -5,6 +5,11 @@ on:
   push:
   pull_request:
 
+# lychee uses GITHUB_TOKEN only to raise its github.com rate limit
+# (read-only API calls).
+permissions:
+  contents: read
+
 jobs:
   linkchecker:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` for the only workflow here. `lycheeverse/lychee-action` uses the token solely to raise lychee's github.com rate limit (read-only API), so `contents: read` is sufficient.

YAML validated locally.